### PR TITLE
fix(rules|lint): Use short_path

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 
-module(name = "masorange_rules_helm", version = "1.3.0", bazel_compatibility = [">=6.0.0"])
+module(name = "masorange_rules_helm", version = "1.3.1", bazel_compatibility = [">=6.0.0"])
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.3.0")
 

--- a/helm/private/helm_lint_test.bzl
+++ b/helm/private/helm_lint_test.bzl
@@ -26,7 +26,7 @@ def _helm_lint_test_impl(ctx):
         output = ctx.outputs.executable,
         content = """
           {helm} lint {chart}
-        """.format(helm=helm_bin.path, chart=chart_targz.short_path),
+        """.format(helm=helm_bin.short_path, chart=chart_targz.short_path),
     )
 
     return [


### PR DESCRIPTION
Use `short_path` instead of `path` in `helm_lint_test.bzl` tested on **mm-monorepo** over bazel 7.4

With `path`
```
(09:01:54) FAIL: //pkg/commons/helm/bitnami-common:chart_lint (see /private/var/tmp/_bazel_carlos.gamez/35fae358f928ae0e57c2ebd504b42380/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/pkg/commons/helm/bitnami-common/chart_lint/test.log)
(09:01:54) INFO: From Testing //pkg/commons/helm/bitnami-common:chart_lint:
==================== Test output for //pkg/commons/helm/bitnami-common:chart_lint:
/private/var/tmp/_bazel_carlos.gamez/35fae358f928ae0e57c2ebd504b42380/sandbox/darwin-sandbox/3/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/pkg/commons/helm/bitnami-common/chart_lint.runfiles/_main/pkg/commons/helm/bitnami-common/chart_lint: line 2: external/masorange_rules_helm~~toolchains~helm_darwin_arm64/helm: No such file or directory
================================================================================
```

With `short_path`
```
(09:03:57) INFO: Found 1 test target...
Target //pkg/commons/helm/bitnami-common:chart_lint up-to-date:
  bazel-bin/pkg/commons/helm/bitnami-common/chart_lint
(09:03:57) INFO: Elapsed time: 4.885s, Critical Path: 0.48s
(09:03:57) INFO: 3 processes: 1 internal, 2 darwin-sandbox.
(09:03:57) INFO: Build completed successfully, 3 total actions
```