### PR TITLE
fix(helm_push): Fix use helm_bin.short_path

### DIFF
--- a/helm/private/helm_push.bzl
+++ b/helm/private/helm_push.bzl
@@ -127,7 +127,7 @@ fi
             # We use short_path because it's a runfile
             "{CHART_PATH}": chart.short_path,
             "{CHART_NAME}": chart_name,
-            "{HELM_BINARY}": helm_bin.path,
+            "{HELM_BINARY}": helm_bin.short_path,
             "{REMOTE}": repo_url,
             "{REPO_CONFIG_PATH}": repo_config_path
         },


### PR DESCRIPTION
Use **.short_path** instead of **.path** to fix Bazel 7 compatibility.
tested on [mm-monorepo ](https://ci-masstack.masstack.com/job/mas-stack/job/mm-monorepo-publish-pr/job/PR-58716/10/pipeline-graph/)over Bazel 7.4.1 versión