### PR TITLE
fix(helm): use bin short_path and kubernetes_context as string

### DIFF
--- a/docs/helm_release.md
+++ b/docs/helm_release.md
@@ -46,7 +46,7 @@ helm_release(
     chart = ":chart",
     release_name = "release-name",
     values = glob(["charts/myapp/values.yaml"]),
-    kubernetes_context = "mm-k8s-c<ontext",
+    kubernetes_context = "mm-k8s-context",
 )
 ```
 
@@ -92,7 +92,7 @@ helm_release(
 | <a id="helm_release-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="helm_release-chart"></a>chart |  The packaged chart archive to be published. It can be a reference to a `helm_chart` rule or a reference to a helm archived file. To specify a helm chart from a remote repository use `remote_chart` instead.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="helm_release-create_namespace"></a>create_namespace |  A flag to indicate helm binary to create the kubernetes namespace if it is not already present in the cluster.   | Boolean | optional |  `True`  |
-| <a id="helm_release-kubernetes_context"></a>kubernetes_context |  Reference to a kubernetes context file used by helm binary.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="helm_release-kubernetes_context"></a>kubernetes_context |  The name of the kubeconfig context to use.   | String | optional |  `None`  |
 | <a id="helm_release-namespace"></a>namespace |  The namespace literal where to install the helm release. Set to `""` to use namespace from current kube context   | String | optional |  `""`  |
 | <a id="helm_release-namespace_dep"></a>namespace_dep |  A reference to a `k8s_namespace` rule from where to extract the namespace to be used to install the release.Namespace where this release is installed to. Must be a label to a k8s_namespace rule. It takes precedence over namespace   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="helm_release-release_name"></a>release_name |  The name of the helm release to be installed or upgraded.   | String | required |  |

--- a/docs/helm_uninstall.md
+++ b/docs/helm_uninstall.md
@@ -25,7 +25,7 @@ This rule builds an executable. Use `run` instead of `build` to be uninstall the
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="helm_uninstall-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
-| <a id="helm_uninstall-kubernetes_context"></a>kubernetes_context |  Reference to a kubernetes context file tu be used by helm binary.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
+| <a id="helm_uninstall-kubernetes_context"></a>kubernetes_context |  The name of the kubeconfig context to use.  | String | optional |  `None`  |
 | <a id="helm_uninstall-namespace"></a>namespace |  The namespace where the helm release is installed.   | String | optional |  `""`  |
 | <a id="helm_uninstall-namespace_dep"></a>namespace_dep |  A reference to a `k8s_namespace` rule from where to extract the namespace where the helm release is installed.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional |  `None`  |
 | <a id="helm_uninstall-release_name"></a>release_name |  The name of the helm release to be installed or upgraded.   | String | required |  |

--- a/docs/k8s_namespace.md
+++ b/docs/k8s_namespace.md
@@ -74,7 +74,7 @@ Example of use with `helm_release`:
 | <a id="k8s_namespace-gcp_gke_project"></a>gcp_gke_project |  -   | String | optional |  `""`  |
 | <a id="k8s_namespace-gcp_sa"></a>gcp_sa |  GCP Service Account in e-mail format.   | String | optional |  `""`  |
 | <a id="k8s_namespace-gcp_sa_project"></a>gcp_sa_project |  CP project name where Service Account lives.   | String | optional |  `""`  |
-| <a id="k8s_namespace-kubernetes_context"></a>kubernetes_context |  -   | String | optional |  `""`  |
+| <a id="k8s_namespace-kubernetes_context"></a>kubernetes_context |   The name of the kubeconfig context to use.    | String | optional |  `""`  |
 | <a id="k8s_namespace-kubernetes_sa"></a>kubernetes_sa |  Kubernetes Service Account to associate with Workload Identity.   | String | optional |  `""`  |
 | <a id="k8s_namespace-namespace_name"></a>namespace_name |  Name of the namespace to be created.   | String | required |  |
 | <a id="k8s_namespace-workload_identity_namespace"></a>workload_identity_namespace |  Workload Identity Namespace e.g clustername.svc.id.goog   | String | optional |  `""`  |

--- a/helm/private/helm_release.bzl
+++ b/helm/private/helm_release.bzl
@@ -99,8 +99,7 @@ _ATTRS = {
 
 def _helm_release_impl(ctx):
     files = []
-
-    print("helm_info {}", ctx.toolchains["@masorange_rules_helm//helm:helm_toolchain_type"].helminfo.bin)
+    
     helm_bin = ctx.toolchains["@masorange_rules_helm//helm:helm_toolchain_type"].helminfo.bin
 
     namespace = ctx.attr.namespace_dep[NamespaceDataInfo].namespace if ctx.attr.namespace_dep else ctx.attr.namespace

--- a/helm/private/helm_release.bzl
+++ b/helm/private/helm_release.bzl
@@ -36,7 +36,7 @@ helm_release(
     chart = ":chart",
     release_name = "release-name",
     values = glob(["charts/myapp/values.yaml"]),
-    kubernetes_context = "mm-k8s-c<ontext",
+    kubernetes_context = "mm-k8s-context",
 )
 ```
 
@@ -86,7 +86,7 @@ _ATTRS = {
   "namespace_dep": attr.label(mandatory = False, doc = "A reference to a `k8s_namespace` rule from where to extract the namespace to be used to install the release.Namespace where this release is installed to. Must be a label to a k8s_namespace rule. It takes precedence over namespace"),
   "values": attr.label_list(allow_files = True, default = [], doc = "A list of value files to be provided to helm install command through -f flag."),
   "release_name": attr.string(mandatory = True, doc = "The name of the helm release to be installed or upgraded."),
-  "kubernetes_context": attr.label(mandatory = False, allow_single_file = True, doc = "Reference to a kubernetes context file used by helm binary."),
+  "kubernetes_context": attr.string(mandatory = False, doc = "The name of the kubeconfig context to use"),
   "create_namespace": attr.bool(default = True, doc = "A flag to indicate helm binary to create the kubernetes namespace if it is not already present in the cluster."),
   "wait": attr.bool(default = True, doc = "Helm flag to wait for all resources to be created to exit."),
   "set": attr.string_dict(doc = """
@@ -100,6 +100,7 @@ _ATTRS = {
 def _helm_release_impl(ctx):
     files = []
 
+    print("helm_info {}", ctx.toolchains["@masorange_rules_helm//helm:helm_toolchain_type"].helminfo.bin)
     helm_bin = ctx.toolchains["@masorange_rules_helm//helm:helm_toolchain_type"].helminfo.bin
 
     namespace = ctx.attr.namespace_dep[NamespaceDataInfo].namespace if ctx.attr.namespace_dep else ctx.attr.namespace
@@ -125,7 +126,7 @@ def _helm_release_impl(ctx):
       args.append("--create-namespace")
 
     if ctx.attr.kubernetes_context:
-      args += ["--kube-context", ctx.attr.file.kubernetes_context.short_path]
+      args += ["--kube-context", ctx.attr.kubernetes_context]
 
     if ctx.attr.wait:
       args.append("--wait")
@@ -154,7 +155,7 @@ def _helm_release_impl(ctx):
         output = exec_file,
         content = """
           {helm} {args}
-        """.format(helm=helm_bin.path, args=" ".join(args)),
+        """.format(helm=helm_bin.short_path, args=" ".join(args)),
         is_executable = True
     )
 

--- a/helm/private/helm_uninstall.bzl
+++ b/helm/private/helm_uninstall.bzl
@@ -15,7 +15,7 @@ _ATTRS = {
   "namespace": attr.string(mandatory = False, doc = "The namespace where the helm release is installed."),
   "namespace_dep": attr.label(mandatory = False, doc = "A reference to a `k8s_namespace` rule from where to extract the namespace where the helm release is installed."),
   "release_name": attr.string(mandatory = True, doc = "The name of the helm release to be installed or upgraded."),
-  "kubernetes_context": attr.label(mandatory = False, allow_single_file = True, doc = "Reference to a kubernetes context file tu be used by helm binary."),
+  "kubernetes_context": attr.string(mandatory = False, doc = "The name of the kubeconfig context to use"),
   "wait": attr.bool(default = True, doc = "Helm flag to wait for all resources to be created to exit."),
 }
 def _helm_uninstall_impl(ctx):
@@ -36,7 +36,7 @@ def _helm_uninstall_impl(ctx):
         args += ["--namespace", namespace]
 
     if ctx.attr.kubernetes_context:
-      args += ['--kube-context', ctx.attr.file.kubernetes_context.short_path]
+      args += ['--kube-context', ctx.attr.kubernetes_context]
 
     if ctx.attr.wait:
       args.append('--wait')
@@ -47,7 +47,7 @@ def _helm_uninstall_impl(ctx):
         output = exec_file,
         content = """
           {helm} {args}
-        """.format(helm=helm_bin.path, args=" ".join(args)),
+        """.format(helm=helm_bin.short_path, args=" ".join(args)),
         is_executable = True
     )
 


### PR DESCRIPTION
This pull request includes several changes to the documentation and implementation of the `helm_release` and `helm_uninstall` rules. The main focus is on correcting and clarifying the usage of the `kubernetes_context` attribute.

Documentation updates:

* [`docs/helm_release.md`](diffhunk://#diff-a4cc2c326309a4b4fe8bb6ca85ce7b45801134eedb29013b5fe65c405fb867c2L49-R49): Corrected the `kubernetes_context` attribute description and fixed a typo in the example usage. [[1]](diffhunk://#diff-a4cc2c326309a4b4fe8bb6ca85ce7b45801134eedb29013b5fe65c405fb867c2L49-R49) [[2]](diffhunk://#diff-a4cc2c326309a4b4fe8bb6ca85ce7b45801134eedb29013b5fe65c405fb867c2L95-R95)
* [`docs/helm_uninstall.md`](diffhunk://#diff-c359b7aa268b55e8006b08796d142616540154e7df8af4a21c011f4368d03e22L28-R28): Updated the description of the `kubernetes_context` attribute.
* [`docs/k8s_namespace.md`](diffhunk://#diff-4ce456fb407507f632064c75ba850c4a3a56a1d30d3e6aef384cb9289ca52db1L77-R77): Clarified the description of the `kubernetes_context` attribute.

Implementation updates:

* [`helm/private/helm_release.bzl`](diffhunk://#diff-4adaf5e0d93090de87721736126fe7f59a551349dc54c6806be12c5ccd952fdfL39-R39): Changed the type of the `kubernetes_context` attribute from `label` to `string` and updated the corresponding logic in the `helm_release` implementation. [[1]](diffhunk://#diff-4adaf5e0d93090de87721736126fe7f59a551349dc54c6806be12c5ccd952fdfL39-R39) [[2]](diffhunk://#diff-4adaf5e0d93090de87721736126fe7f59a551349dc54c6806be12c5ccd952fdfL89-R89) [[3]](diffhunk://#diff-4adaf5e0d93090de87721736126fe7f59a551349dc54c6806be12c5ccd952fdfL128-R129) [[4]](diffhunk://#diff-4adaf5e0d93090de87721736126fe7f59a551349dc54c6806be12c5ccd952fdfL157-R158)
* [`helm/private/helm_uninstall.bzl`](diffhunk://#diff-4885b016b1d613d66b57ca0bc568c5d0005fc91391ab22421f272c3aef178471L18-R18): Changed the type of the `kubernetes_context` attribute from `label` to `string` and updated the corresponding logic in the `helm_uninstall` implementation. [[1]](diffhunk://#diff-4885b016b1d613d66b57ca0bc568c5d0005fc91391ab22421f272c3aef178471L18-R18) [[2]](diffhunk://#diff-4885b016b1d613d66b57ca0bc568c5d0005fc91391ab22421f272c3aef178471L39-R39) [[3]](diffhunk://#diff-4885b016b1d613d66b57ca0bc568c5d0005fc91391ab22421f272c3aef178471L50-R50)
* Fix **helm_bin path** using `helm_bin.short_path` instead of `helm_bin.short`