### PR TITLE
fix: override newer zlib to unblock build on macos

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,11 @@ bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "rules_pkg", version = "0.9.1")
 
 bazel_dep(name = "rules_oci", version = "1.6.0")
+
+# override zlib-1.2.13 in deps from @bazel_tools and @protobuf
+# may be removable if newer bazel versions carry in newer bazel_tools
+bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
+
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True)
 
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci", dev_dependency = True)


### PR DESCRIPTION
Fixes #95 

In a build on macOS/arm64 or macOS/x86_64, the `zlib-1.2.13/zutil.h` header file has non-mututally-exclusive `#define` statements that fail the build:

```
#if defined(MACOS) || defined(TARGET_OS_MAC)
#  define OS_CODE  7
#  ifndef Z_SOLO
#    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
#      include <unix.h> /* for fdopen */
#    else
#      ifndef fdopen
#        define fdopen(fd,mode) NULL /* No fdopen() */
#      endif
#    endif
#  endif
#endif

...

#ifdef __APPLE__
#  define OS_CODE 19
#endif
```

This is a transitive dependency through `@bazel_tools` (zlib-1.2.13) and `@protobuf` (zlib-1.2.11).  by providing a `bazel_dep` with a direct dependency, we override the transitive.  We therefore avoid the error and update our dependency ahead of moving to newer `bazel` versions. 