### PR TITLE
feat: bump rules_pkg dep to v0.10.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ use_repo(bazel_lib_toolchains, "yq_toolchains")
 
 bazel_dep(name = "platforms", version = "0.0.7")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "rules_pkg", version = "0.9.1")
+bazel_dep(name = "rules_pkg", version = "0.10.1")
 
 bazel_dep(name = "rules_oci", version = "1.6.0")
 bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True)


### PR DESCRIPTION
Upgrade rules_pkg to version v0.10.1 to avoid warning messages related to normalization issues.