### PR TITLE
fix: Update .bazelrc to allow functional non-build (ie query)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --enable_bzlmod
+common --enable_bzlmod
 
 test:ci --workspace_status_command=$GITHUB_WORKSPACE/stamp.sh
 


### PR DESCRIPTION
Without this change, `bazel query //...` fails because the `--enable_bzlmod` isn't activated, so the dependencies in `MODULE.bazel` are not available:

```
$ bazel query //... 
Starting local Bazel server and connecting to it...
ERROR: error loading package under directory '': error loading package 'docs': Unable to find package for @aspect_bazel_lib//lib:write_source_files.bzl: The repository '@aspect_bazel_lib' could not be resolved: Repository '@aspect_bazel_lib' is not defined.
```

With this change, `build` (and `test`) should still function, but additionally, `bazel query` works as well: `bzlmod` is activated, so `MODULE.bazel` is parsed, and the dependencies are available.

```
$ bazel query //... 
//docs:gcs_docs
//docs:gcs_docs_stardoc
//docs:helm_chart_docs
//docs:helm_chart_docs_stardoc
//docs:helm_lint_docs
...
```