### PR TITLE
ci: exercise examples to validate on CI

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -18,3 +18,11 @@ jobs:
     - name: Run integration tests
       run: |
         bazel test //... --config=ci
+    - name: Validate Examples
+      # rules_bazel_integration_test doesn't apply to a lone subdir
+      # even so, I'd parallelize with a matrix of <example> x <arch>
+      #
+      # after this test, the checkout is *dirty*: the //examples/ has its own bazel-* links, which
+      # cannot be excluded with .bazelignore
+      run: |
+        (cd examples/ && bazel test //... --config=ci)


### PR DESCRIPTION
This PR adds to the PR CI so that after the basic test runs, the examples are also run.
- as commented in CI, a single directory is not suitable for rules_bazel_integration_tests
- even so, since rules_bazel_integration_tests is sequential, I'd prefer to run them through a marix so that examples build In parallel but dependent on the basic test's successful completion
- `.bazelignore` keeps the `examples` entry: the `cd examples` in CI causes the `//.bazelignore` to be ineffective

This would have caught the issue in #98 as well.