### PR TITLE
fix(helm-chart): append chart version to the packaged output chart name

### DIFF
--- a/examples/chart_multi_version/BUILD.bazel
+++ b/examples/chart_multi_version/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@masorange_rules_helm//helm:defs.bzl", "helm_chart")
+
+helm_chart(
+    name = "package-stable",
+    chart_name = "testt",
+    srcs = glob(['test_chart/**/*.yaml']),
+    version = "v1-stable",
+)
+
+helm_chart(
+    name = "package",
+    chart_name = "testt",
+    srcs = glob(['test_chart/**/*.yaml']),
+    version = "1.0.0",
+)

--- a/examples/chart_multi_version/test_chart/Chart.yaml
+++ b/examples/chart_multi_version/test_chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+name: test-chart
+description: Helm chart for testing
+version: 1.0.0
+appVersion: 1.5.0

--- a/examples/chart_multi_version/test_chart/templates/_helpers.tpl
+++ b/examples/chart_multi_version/test_chart/templates/_helpers.tpl
@@ -1,0 +1,37 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+
+{{/*
+Create a default fully qualified base.name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "base.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default app name based on the namespace
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "base.fullapp" -}}
+{{- default .Release.Namespace .Values.fullappOverride -}}
+{{- end -}}
+
+{{- define "base.basepath" -}}
+{{- $path := (printf "/%s/" (default .Chart.Name .Values.nameOverride )) | trunc 63 | trimSuffix "-" -}}
+{{- default $path .Values.basePath -}}
+{{- end -}}
+
+# http://masterminds.github.io/sprig/string_slice.html
+# http://masterminds.github.io/sprig/lists.html
+
+{{ define "dirname" -}}
+{{ splitList "/" . | initial | join "/"}}
+{{- end -}}
+
+{{ define "filename" -}}
+{{ splitList "/" . | last | join "/"}}
+{{- end -}}

--- a/examples/chart_multi_version/test_chart/templates/deployment.yaml
+++ b/examples/chart_multi_version/test_chart/templates/deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-name
+  labels:
+    app: app-name
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: app-name
+  template:
+    metadata:
+      labels:
+        app: app-name
+    spec:
+      containers:
+        - name: app-name
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/examples/chart_multi_version/test_chart/templates/svc.yaml
+++ b/examples/chart_multi_version/test_chart/templates/svc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-name
+spec:
+  type: ClusterIP
+  ports:
+    - name: http-metrics
+      port: 9091
+      protocol: TCP
+      targetPort: metrics
+  selector:
+    app: deployment

--- a/examples/chart_multi_version/test_chart/values.yaml
+++ b/examples/chart_multi_version/test_chart/values.yaml
@@ -1,0 +1,5 @@
+labels:
+  somelabel: labelvalue
+image:
+  tag: latest
+  repository: aio

--- a/helm/defs.bzl
+++ b/helm/defs.bzl
@@ -14,22 +14,6 @@ load("//helm/private:chart_srcs.bzl", _chart_srcs = "chart_srcs")
 load("//helm/private:helm_pull.bzl", _helm_pull = "helm_pull", _pull_attr = "pull_attrs")
 load("//helm/private:helm_chart_providers.bzl", _chart_info = "ChartInfo", _helm_chart_providers = "helm_chart_providers")
 
-# def helm_chart(name, **kwargs):
-#     image = kwargs.get("image")
-
-#     if image:
-#         _helm_chart(
-#             name = name,
-#             image_digest = image + ".digest",
-#             **kwargs,
-#         )
-#     else:
-#         _helm_chart(
-#             name = name,
-#             **kwargs,
-#         )
-
-
 # Explicitly re-export the functions
 helm_push = _helm_push
 helm_chart = _helm_chart

--- a/helm/helm.bzl
+++ b/helm/helm.bzl
@@ -1,32 +1,25 @@
-"""Maintained as public export api for retro-compatibility"""
+"""Rules for manipulating helm charts. To load these rules:
 
-load("//helm:defs.bzl",
-    _helm_chart = "helm_chart",
-    _helm_pull = "helm_pull",
-    _helm_push = "helm_push",
-    _helm_release = "helm_release",
-    _helm_lint = "helm_lint_test",
-    _helm_uninstall = "helm_uninstall",
-    _chart_info = "ChartInfo"
-)
+```starlark
+load("//helm:defs.bzl", "helm_chart", ...)
+```
+"""
 
-def helm_chart(name, **kwargs):
-    image = kwargs.get("image")
-
-    if image:
-        _helm_chart(
-            name = name,
-            image_digest = image + ".digest",
-            **kwargs,
-        )
-    else:
-        _helm_chart(
-            name = name,
-            **kwargs,
-        )
+load("//helm/private:helm_push.bzl", _helm_push = "helm_push")
+load("//helm/private:helm_release.bzl", _helm_release = "helm_release")
+load("//helm/private:helm_uninstall.bzl", _helm_uninstall = "helm_uninstall")
+load("//helm/private:helm_lint_test.bzl", _helm_lint = "helm_lint_test")
+load("//helm/private:helm_chart.bzl", _helm_chart = "helm_chart")
+load("//helm/private:chart_srcs.bzl", _chart_srcs = "chart_srcs")
+load("//helm/private:helm_pull.bzl", _helm_pull = "helm_pull", _pull_attr = "pull_attrs")
+load("//helm/private:helm_chart_providers.bzl", _chart_info = "ChartInfo", _helm_chart_providers = "helm_chart_providers")
 
 # Explicitly re-export the functions
 helm_push = _helm_push
+helm_chart = _helm_chart
+chart_srcs = _chart_srcs
+helm_chart_providers = _helm_chart_providers
+pull_attrs = _pull_attr
 helm_pull = _helm_pull
 helm_release = _helm_release
 helm_uninstall = _helm_uninstall

--- a/helm/private/chart_srcs.bzl
+++ b/helm/private/chart_srcs.bzl
@@ -340,7 +340,7 @@ def _chart_srcs_impl(ctx):
     # copy all chart source files to the output bin directory
     # values.yaml are not copied to the output dir here to be able to modify the sources
     for file in _filter_manifest_and_values_from_files(ctx.files.srcs):
-        copied_file = ctx.actions.declare_file(paths.join(chart_name, file.path.replace(chart_root_path + "/", "")))
+        copied_file = ctx.actions.declare_file(paths.join(ctx.attr.name, chart_name, file.path.replace(chart_root_path + "/", "")))
         copied_src_files += [copied_file]
         copy_file_action(
             ctx=ctx,
@@ -353,7 +353,7 @@ def _chart_srcs_impl(ctx):
     copied_tpl_files = []
 
     for template in additional_templates:
-        copied_tpl = ctx.actions.declare_file(paths.join(chart_name, "templates", template.basename))
+        copied_tpl = ctx.actions.declare_file(paths.join(ctx.attr.name, chart_name, "templates", template.basename))
         copied_tpl_files += [copied_tpl]
         copy_file_action(
             ctx=ctx,
@@ -362,7 +362,7 @@ def _chart_srcs_impl(ctx):
         )
 
     # rewrite Chart.yaml to override chart info
-    out_chart_yaml = ctx.actions.declare_file(paths.join(chart_name, "Chart.yaml"))
+    out_chart_yaml = ctx.actions.declare_file(paths.join(ctx.attr.name, chart_name, "Chart.yaml"))
 
     yq_subst_expr = _create_yq_substitution_file(ctx, "%s_yq_chart_subst_expr" % ctx.attr.name, _get_manifest_subst_args(ctx, chart_deps, chart_yaml == None))
 
@@ -443,7 +443,7 @@ def _chart_srcs_impl(ctx):
     yq_expression_file = _create_yq_substitution_file(ctx, "%s_yq_values_subst_expression_file" % ctx.attr.name, all_values)
 
     output_values_script_yaml = ctx.actions.declare_file("%s_subst_values.sh" % ctx.attr.name)
-    output_values_yaml = ctx.actions.declare_file(paths.join(chart_name, "values.yaml"))
+    output_values_yaml = ctx.actions.declare_file(paths.join(ctx.attr.name, chart_name, "values.yaml"))
 
     values_substitutions = {
         "{yq}": yq_bin.path,
@@ -493,7 +493,7 @@ def _chart_srcs_impl(ctx):
         dep_chart_files = _locate_chart_roots(dep.srcs, "", dep.name)
 
         for dep_src in dep.srcs:
-            out_path = paths.join(chart_name, "charts", dep.name, dep_src.path.replace(dep_chart_files.root + "/", ""))
+            out_path = paths.join(ctx.attr.name, chart_name, "charts", dep.name, dep_src.path.replace(dep_chart_files.root + "/", ""))
 
             dep_out = ctx.actions.declare_file(out_path)
 

--- a/helm/private/chart_srcs.bzl
+++ b/helm/private/chart_srcs.bzl
@@ -16,7 +16,6 @@ This rule should not be used directly, users should use `helm_chart` macro inste
 Despite, if you want to see the configuration arguments you can use to package a helm chart using `helm_chart` rule, check the arguments doc below for `chart_srcs` rule,
 as `helm_chart` is just a wrapper around `chart_srcs` rule and all the arguments are propagated to `chart_srcs` rule.
 
-
 This rule takes chart src files and write them to bazel output dir applying some modifications.
 The rule is designed to be used with a packager to produce an archived file (`pkg_tar` is used).
 

--- a/helm/private/helm_chart.bzl
+++ b/helm/private/helm_chart.bzl
@@ -89,14 +89,14 @@ def helm_chart(name, chart_name, **kwargs):
         All: This is a wrapper around `chart_srcs` rule. All the args are propagated to `chart_srcs`. See [chart_srcs](#chart_srcs)
             to check the available config.
     """
+    chart_version = kwargs.get("version") or kwargs.get("helm_chart_version")
 
 
-    helm_pkg_target = "%s_package" % name
+    helm_pkg_target = "{}_{}_package".format(name, chart_version)
     helm_pkg_out_strip_target = "%s_src_helm_files" % name
     tar_target = "%s_tar" % name
 
     image = kwargs.get("image")
-    chart_version = kwargs.get("version") or kwargs.get("helm_chart_version")
     # TODO: change how visibility is propagated
     visibility = kwargs.get("visibility") or ["//visibility:public"]
 
@@ -114,7 +114,7 @@ def helm_chart(name, chart_name, **kwargs):
     pkg_files(
         name = helm_pkg_out_strip_target,
         srcs = [helm_pkg_target],
-        strip_prefix = strip_prefix.from_pkg(),
+        strip_prefix = strip_prefix.from_pkg(helm_pkg_target),
         visibility = visibility,
     )
 

--- a/helm/private/helm_chart.bzl
+++ b/helm/private/helm_chart.bzl
@@ -120,7 +120,7 @@ def helm_chart(name, chart_name, **kwargs):
 
     pkg_tar(
         name = tar_target,
-        out = "%s-%s.tgz".format(chart_name, chart_version) if chart_version else "%s.tgz".format(chart_name),
+        out = "{}-{}.tgz".format(chart_name, chart_version) if chart_version else "{}.tgz".format(chart_name),
         extension = "tgz",
         srcs = [helm_pkg_out_strip_target],
         visibility = visibility,


### PR DESCRIPTION
When you have multiple `helm_chart` rules in the same BUILD file with the same chart name (but with different versions), builds fail because all target outputs have the same name.

This PR try to solve this by appending the version of the chart to the name of the `helm_chart` output, as helm cli does. 

Only the chart version will be appended to the name if it's provided by argument to the `helm_chart` rule.