### PR TITLE
chore: remove incompatible_use_toolchain_transition for Bazel 9 compat

### DIFF
--- a/gcs/private/gcloud_toolchain.bzl
+++ b/gcs/private/gcloud_toolchain.bzl
@@ -191,7 +191,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@masorange_rules_helm//gcs:gcloud_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/helm/private/helm_toolchain.bzl
+++ b/helm/private/helm_toolchain.bzl
@@ -189,7 +189,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@masorange_rules_helm//helm:helm_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/k8s/private/kubectl_toolchain.bzl
+++ b/k8s/private/kubectl_toolchain.bzl
@@ -158,7 +158,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@masorange_rules_helm//k8s:kubectl_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)

--- a/sops/private/sops_toolchain.bzl
+++ b/sops/private/sops_toolchain.bzl
@@ -161,7 +161,6 @@ def _resolved_toolchain_impl(ctx):
 resolved_toolchain = rule(
     implementation = _resolved_toolchain_impl,
     toolchains = ["@masorange_rules_helm//sops:sops_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 """
     rctx.file("defs.bzl", starlark_content)


### PR DESCRIPTION
## Summary

`incompatible_use_toolchain_transition` was deprecated in Bazel 7 and **removed in Bazel 9** — calling
`rule(incompatible_use_toolchain_transition = True, ...)` now raises:

```
Error in rule: rule() got unexpected keyword argument 'incompatible_use_toolchain_transition'
```

Toolchain transitions are unconditional in Bazel 9, so the kwarg is a no-op there. It was already a no-op on Bazel 7/8 (the flag had been flipped to default-on long ago), so removing it is safe across 7.x/8.x/9.x.

Affected files — all of them are the same generated `resolved_toolchain = rule(...)` block inside the templates that the module extension writes to disk:

- `helm/private/helm_toolchain.bzl`
- `sops/private/sops_toolchain.bzl`
- `k8s/private/kubectl_toolchain.bzl`
- `gcs/private/gcloud_toolchain.bzl`

Without this fix, every consumer of `masorange_rules_helm` on Bazel 9 has to apply a local `git_override(patches=...)` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)