### PR TITLE
chore: drop Bazel 6 support

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -7,7 +7,6 @@ bcr_test_module:
     - macos
     - macos_arm64
     bazel:
-    - 6.x
     - 7.x
     - 8.x
     - 9.x

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,5 @@
 
-module(name = "masorange_rules_helm", version = "0.0.0", bazel_compatibility = [">=6.0.0"])
+module(name = "masorange_rules_helm", version = "0.0.0", bazel_compatibility = [">=7.0.0"])
 
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.4")
 


### PR DESCRIPTION
Bazel 6 is unmaintained; transitive deps (aspect_bazel_lib >= 2.22.4 via #105) need Bazel 7+. The bcr-presubmit failures for [bazel-central-registry#9179](https://github.com/bazelbuild/bazel-central-registry/pull/9179) (v1.8.1) are exactly that — all `bazel6.x-*` jobs fail, 7/8/9 pass.

After merge: tag v1.8.2 → publish-to-bcr opens a clean PR.